### PR TITLE
update several dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/@cimpresscloud/metafig/-/metafig-0.2.3.tgz",
       "integrity": "sha1-wje7AbN9kbHl+gwH3BuYFGU26w8=",
       "requires": {
-        "aws-sdk": "2.149.0",
+        "aws-sdk": "2.171.0",
         "es6-promisify": "5.0.0",
         "lodash": "4.17.4",
         "ssm-params": "0.0.6"
@@ -148,9 +148,9 @@
         "apollo-link-core": "0.5.4",
         "graphql": "0.10.5",
         "graphql-anywhere": "3.1.0",
-        "graphql-tag": "2.5.0",
+        "graphql-tag": "2.6.0",
         "redux": "3.7.2",
-        "symbol-observable": "1.0.4",
+        "symbol-observable": "1.1.0",
         "whatwg-fetch": "2.0.3"
       }
     },
@@ -161,7 +161,7 @@
       "dev": true,
       "requires": {
         "graphql": "0.10.5",
-        "graphql-tag": "2.5.0",
+        "graphql-tag": "2.6.0",
         "zen-observable-ts": "0.4.4"
       }
     },
@@ -269,9 +269,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.149.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.149.0.tgz",
-      "integrity": "sha1-dvU3Iqd4C9sxkeg/J8EBCMb+mBM=",
+      "version": "2.171.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.171.0.tgz",
+      "integrity": "sha1-acJWXpjjU9Q3QCR3zDBkoTyu3Jw=",
       "requires": {
         "buffer": "4.9.1",
         "crypto-browserify": "1.0.9",
@@ -403,9 +403,9 @@
       }
     },
     "boxen": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
-      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
@@ -414,7 +414,7 @@
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
-        "widest-line": "1.0.0"
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -555,9 +555,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
     },
     "circular-json": {
@@ -729,7 +729,7 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "proto-list": "1.2.4"
       }
     },
@@ -1035,13 +1035,12 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dot-prop": {
@@ -1157,9 +1156,9 @@
       }
     },
     "eslint": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.11.0.tgz",
-      "integrity": "sha512-UWbhQpaKlm8h5x/VLwm0S1kheMrDj8jPwhnBMjr/Dlo3qqT7MvcN/UfKAR3E1N4lr4YNtOvS4m3hwsrVc/ky7g==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.13.1.tgz",
+      "integrity": "sha512-UCJVV50RtLHYzBp1DZ8CMPtRSg4iVZvjgO9IJHIKyWU/AnJVjtdRikoUPLB29n5pzMB7TnsLQWf0V6VUJfoPfw==",
       "dev": true,
       "requires": {
         "ajv": "5.3.0",
@@ -1168,7 +1167,7 @@
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.0",
+        "doctrine": "2.0.2",
         "eslint-scope": "3.7.1",
         "espree": "3.5.2",
         "esquery": "1.0.0",
@@ -1177,11 +1176,11 @@
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.1.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
+        "is-resolvable": "1.0.1",
         "js-yaml": "3.10.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
@@ -1235,6 +1234,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "globals": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -1676,12 +1681,12 @@
       }
     },
     "global-dirs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
-      "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4"
+        "ini": "1.3.5"
       }
     },
     "globals": {
@@ -1760,9 +1765,9 @@
       "dev": true
     },
     "graphql-tag": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.5.0.tgz",
-      "integrity": "sha1-tDv9i1urzSwgWtaAwD6YsjiTTg8=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.6.0.tgz",
+      "integrity": "sha1-D7G59tZlEmPEejQg6CeRDm/tOVI=",
       "dev": true
     },
     "growl": {
@@ -1947,9 +1952,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -2077,7 +2082,7 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.0",
+        "global-dirs": "0.1.1",
         "is-path-inside": "1.0.0"
       }
     },
@@ -2142,13 +2147,10 @@
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -2524,9 +2526,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.0.tgz",
-      "integrity": "sha512-rPO6R1t8PjYL6xbsFUg7aByKkWAql907na6powPBORVs4DCm8aMBUkL4+6CXO0gEIV8vtu3mWV0FB8ZaCYPBmA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
       "dev": true
     },
     "longest": {
@@ -2605,9 +2607,9 @@
       "dev": true
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -2698,9 +2700,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.0.tgz",
+      "integrity": "sha512-r7aEpLB/mhMUiC5ksahDajF/Jr3wS/qLzUnwOJCZyKWF34ibdvW8saujBKfR7aQlov//JgFA38HXOoIt7lXzcA==",
       "dev": true
     },
     "ms": {
@@ -3079,7 +3081,7 @@
       "dev": true,
       "requires": {
         "native-promise-only": "0.8.1",
-        "superagent": "3.8.1"
+        "superagent": "3.8.2"
       }
     },
     "path-parse": {
@@ -3292,7 +3294,7 @@
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
@@ -3356,7 +3358,7 @@
         "lodash": "4.17.4",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.1.0"
       }
     },
     "regenerator-runtime": {
@@ -3625,19 +3627,19 @@
       }
     },
     "serverless": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.24.0.tgz",
-      "integrity": "sha1-Z9rV8DpVEdY1iTM3o+jBSQy4slc=",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.24.1.tgz",
+      "integrity": "sha1-3QkqGG1ATcnkgVHR98wt99JwNVo=",
       "dev": true,
       "requires": {
         "@serverless/fdk": "0.5.1",
         "apollo-client": "1.9.3",
         "archiver": "1.3.0",
         "async": "1.5.2",
-        "aws-sdk": "2.149.0",
+        "aws-sdk": "2.171.0",
         "bluebird": "3.5.1",
         "chalk": "2.3.0",
-        "ci-info": "1.1.1",
+        "ci-info": "1.1.2",
         "download": "5.0.3",
         "filesize": "3.5.11",
         "fs-extra": "0.26.7",
@@ -3645,7 +3647,7 @@
         "globby": "6.1.0",
         "graceful-fs": "4.1.11",
         "graphql": "0.10.5",
-        "graphql-tag": "2.5.0",
+        "graphql-tag": "2.6.0",
         "https-proxy-agent": "1.0.0",
         "is-docker": "1.1.0",
         "js-yaml": "3.10.0",
@@ -3653,7 +3655,7 @@
         "jwt-decode": "2.2.0",
         "lodash": "4.17.4",
         "minimist": "1.2.0",
-        "moment": "2.19.2",
+        "moment": "2.20.0",
         "node-fetch": "1.7.3",
         "node-forge": "0.7.1",
         "opn": "5.1.0",
@@ -3756,9 +3758,9 @@
       }
     },
     "serverless-plugin-common-excludes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/serverless-plugin-common-excludes/-/serverless-plugin-common-excludes-2.0.0.tgz",
-      "integrity": "sha1-Cx6b4Vn6uilAmddkCGOJdOCuZFk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-common-excludes/-/serverless-plugin-common-excludes-2.0.1.tgz",
+      "integrity": "sha1-k69A3JgotNJGemqn/S4HUCnQW74=",
       "dev": true
     },
     "set-blocking": {
@@ -3849,15 +3851,15 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.2.tgz",
-      "integrity": "sha512-5uLBZPdCWl59Lpbf45ygKj7Z0LVol+ftBe7RDIXOQV/sF58pcFmbK8raA7bt6eljNuGnvBP+/ZxlicVn0emDjA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.3.tgz",
+      "integrity": "sha512-c7u0ZuvBRX1eXuB4jN3BRCAOGiUTlM8SE3TxbJHrNiHUKL7wonujMOB6Fi1gQc00U91IscFORQHDga/eccqpbw==",
       "dev": true,
       "requires": {
         "diff": "3.3.1",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.0",
+        "lolex": "2.3.1",
         "nise": "1.2.0",
         "supports-color": "4.5.0",
         "type-detect": "4.0.5"
@@ -4076,9 +4078,9 @@
       }
     },
     "superagent": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
-      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -4088,7 +4090,7 @@
         "form-data": "2.3.1",
         "formidable": "1.1.1",
         "methods": "1.1.2",
-        "mime": "1.4.1",
+        "mime": "1.6.0",
         "qs": "6.5.1",
         "readable-stream": "2.3.3"
       },
@@ -4111,9 +4113,9 @@
       "dev": true
     },
     "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
       "dev": true
     },
     "table": {
@@ -4369,12 +4371,6 @@
         "escape-string-regexp": "1.0.5"
       }
     },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4527,7 +4523,7 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.2.2",
+        "boxen": "1.3.0",
         "chalk": "2.3.0",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
@@ -4679,25 +4675,12 @@
       "dev": true
     },
     "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        }
+        "string-width": "2.1.1"
       }
     },
     "window-size": {

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "main": "handler.js",
   "dependencies": {
     "@cimpresscloud/metafig": "^0.2.3",
-    "aws-sdk": "^2.149.0",
+    "aws-sdk": "^2.171.0",
     "request": "^2.83.0",
     "request-promise": "^4.2.2"
   },
   "devDependencies": {
     "depcheck": "^0.6.8",
-    "eslint": "^4.11.0",
+    "eslint": "^4.13.1",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",
@@ -23,10 +23,10 @@
     "proxyquire": "^1.8.0",
     "readline-sync": "^1.4.7",
     "sepia": "^2.0.2",
-    "serverless": "1.24.0",
-    "serverless-plugin-common-excludes": "^2.0.0",
+    "serverless": "^1.24.1",
+    "serverless-plugin-common-excludes": "^2.0.1",
     "should": "^13.0.0",
-    "sinon": "^4.1.2",
+    "sinon": "^4.1.3",
     "ssm-params": "0.0.6"
   },
   "scripts": {


### PR DESCRIPTION
Newest serverless no longer pulls in [a bad version of moment](https://snyk.io/vuln/npm:moment:20170905).

I thought we had ignored that in in nsp since it's not runtime, but maybe that was another project. But if we do have an exception defined somewhere in this project we should remove that.