### PR TITLE
Added protectedKeys config option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ By default, all GitLab settings are loaded from the SSM Parameter Store at `/fel
 
 * `token`: A [GitLab API token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html) that has access to update build variables for your repositories.
 * `url`: The BaseUrl to the GitLab instance you wish to connect to (e.g. `https://gitlab.mycompany.com/`).
+* `protectedKeys`: A boolean value determining if Felix should mark the build variables containing the keys as protected.
 
 #### SumoLogic Settings
 

--- a/configure.js
+++ b/configure.js
@@ -48,6 +48,12 @@ let config = [
         Description: 'The GitLab API token for managing repository settings.',
         KeyId: 'alias/felix/settings',
         Type: 'SecureString'
+      },
+      {
+        Name: 'protectedKeys',
+        default: 'false',
+        Description: 'Should GitLab mark the keys as protected? Protected keys can only be used on protected branches. (true or false)',
+        Type: 'String'
       }
     ]
   },

--- a/lib/plugins/gitlab.js
+++ b/lib/plugins/gitlab.js
@@ -3,6 +3,7 @@ const request = require('request-promise');
 
 class GitLab {
   constructor (settings) {
+    this.setKeysAsProtected = ((settings.protectedKeys === 'true') || (settings.protectedKeys === 'True'));
     this.client = request.defaults({
       baseUrl: settings.url,
       headers: {
@@ -33,7 +34,7 @@ class GitLab {
       body: {
         key: 'AWS_ACCESS_KEY_ID',
         value: key.AccessKeyId,
-        protected: true
+        protected: this.setKeysAsProtected
       }
     })
       .then(() => {
@@ -43,7 +44,7 @@ class GitLab {
           body: {
             key: 'AWS_SECRET_ACCESS_KEY',
             value: key.SecretAccessKey,
-            protected: true
+            protected: this.setKeysAsProtected
           }
         });
       });
@@ -56,7 +57,7 @@ class GitLab {
       body: {
         key: 'AWS_ACCESS_KEY_ID',
         value: key.AccessKeyId,
-        protected: true
+        protected: this.setKeysAsProtected
       }
     })
       .then(() => {
@@ -66,7 +67,7 @@ class GitLab {
           body: {
             key: 'AWS_SECRET_ACCESS_KEY',
             value: key.SecretAccessKey,
-            protected: true
+            protected: this.setKeysAsProtected
           }
         });
       });

--- a/test/fixtures/request/gitlab-api-v4-projects-4-variables
+++ b/test/fixtures/request/gitlab-api-v4-projects-4-variables
@@ -1,0 +1,18 @@
+[
+    {
+        "key": "TEST_VARIABLE_1",
+        "value": "TEST_1"
+    },
+    {
+        "key": "TEST_VARIABLE_2",
+        "value": "TEST_2"
+    },
+    {
+        "key": "AWS_ACCESS_KEY_ID",
+        "value": "Something"
+    },
+    {
+        "key": "AWS_SECRET_ACCESS_KEY",
+        "value": "Something"
+    }
+]

--- a/test/fixtures/request/gitlab-api-v4-projects-4-variables-AWS_ACCESS_KEY_ID
+++ b/test/fixtures/request/gitlab-api-v4-projects-4-variables-AWS_ACCESS_KEY_ID
@@ -1,0 +1,5 @@
+{
+    "key": "AWS_ACCESS_KEY_ID",
+    "value": "updated value",
+    "protected": false
+}

--- a/test/fixtures/request/gitlab-api-v4-projects-4-variables-AWS_SECRET_ACCESS_KEY
+++ b/test/fixtures/request/gitlab-api-v4-projects-4-variables-AWS_SECRET_ACCESS_KEY
@@ -1,0 +1,5 @@
+{
+    "key": "AWS_SECRET_ACCESS_KEY",
+    "value": "updated value",
+    "protected": false
+}


### PR DESCRIPTION
Added 'protectedKeys' config option (stored in AWS Parameter Store) which allows the user to choose if protected build variables should be used in GitLab